### PR TITLE
feat: Add Dropdown atom component

### DIFF
--- a/docs/Dropdown.md
+++ b/docs/Dropdown.md
@@ -1,0 +1,233 @@
+# Dropdown Component
+
+## Overview
+The Dropdown component is an atom-level component that provides a custom-styled select dropdown with enhanced features like keyboard navigation, disabled options, error states, and full accessibility support.
+
+## Figma Reference
+- **URL**: https://www.figma.com/design/ri9qaHxsKZS00ViWhwguiP/%F0%9F%93%8C-PS-Components?node-id=18-304&m=dev
+- **Node ID**: 18:304
+
+## Usage
+
+```tsx
+import Dropdown, { DropdownOption } from '@/components/atoms/Dropdown/Dropdown';
+
+// Basic usage
+const options: DropdownOption[] = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+];
+
+<Dropdown
+  id="size-selector"
+  options={options}
+  value={selectedSize}
+  onChange={setSelectedSize}
+/>
+
+// With label and placeholder
+<Dropdown
+  id="country"
+  label="Country"
+  placeholder="Select a country"
+  options={countryOptions}
+  value={selectedCountry}
+  onChange={setSelectedCountry}
+  required
+/>
+
+// With disabled options
+const options: DropdownOption[] = [
+  { value: 'free', label: 'Free Shipping' },
+  { value: 'standard', label: 'Standard (3-5 days)' },
+  { value: 'express', label: 'Express (1-2 days)', disabled: true },
+];
+
+// With error state
+<Dropdown
+  id="category"
+  label="Category"
+  options={categoryOptions}
+  value={selectedCategory}
+  onChange={setSelectedCategory}
+  error={!selectedCategory}
+  errorMessage="Please select a category"
+  required
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `id` | `string` | - | ✓ | Unique identifier for the dropdown |
+| `name` | `string` | - | - | Name attribute for form submission |
+| `label` | `string` | - | - | Label text above the dropdown |
+| `placeholder` | `string` | `'Select an option'` | - | Placeholder text when no value selected |
+| `options` | `DropdownOption[]` | - | ✓ | Array of options to display |
+| `value` | `string` | - | - | Currently selected value |
+| `onChange` | `(value: string) => void` | - | - | Callback when selection changes |
+| `disabled` | `boolean` | `false` | - | Whether the dropdown is disabled |
+| `required` | `boolean` | `false` | - | Whether the field is required |
+| `error` | `boolean` | `false` | - | Whether to show error state |
+| `errorMessage` | `string` | - | - | Error message to display |
+| `className` | `string` | - | - | Additional CSS class |
+| `aria-label` | `string` | - | - | Custom aria-label |
+| `aria-describedby` | `string` | - | - | ID of element that describes dropdown |
+
+## DropdownOption Interface
+
+```typescript
+interface DropdownOption {
+  value: string;      // Option value
+  label: string;      // Display text
+  disabled?: boolean; // Whether option is disabled
+}
+```
+
+## States
+
+### Visual States
+- **Default**: Closed dropdown with placeholder or selected value
+- **Open**: Dropdown menu visible with options
+- **Hover**: Purple border on trigger, gray background on options
+- **Focus**: Purple outline for accessibility
+- **Disabled**: Grayed out with reduced opacity
+- **Error**: Red border with error message below
+
+### Interactions
+- Click dropdown to open/close menu
+- Click option to select and close menu
+- Click outside to close menu
+- Keyboard navigation:
+  - Enter/Space: Toggle dropdown
+  - Escape: Close dropdown
+  - Arrow Down: Open dropdown
+  - Tab: Navigate through options when open
+
+## Accessibility
+- Full ARIA support with `role="listbox"` and `role="option"`
+- Proper `aria-expanded`, `aria-haspopup`, and `aria-selected` states
+- Keyboard navigation support
+- Screen reader friendly
+- Hidden native select for form compatibility
+- Focus management and indicators
+
+## Styling
+The component uses design system variables exclusively:
+- Border color: `$gray-600` (#757575 from Figma)
+- Background: `$white` (#FFFFFF)
+- Text color: `$black` (#000000)
+- Shadow: `$shadow-radio-selector` (reused from RadioButtonSelector)
+- All spacing uses `$spacing-*` variables
+- Typography uses system fonts and weights
+
+## Examples
+
+### Form with Dropdown
+```tsx
+const ProductForm = () => {
+  const [formData, setFormData] = useState({
+    size: '',
+    color: '',
+    quantity: '1',
+  });
+
+  const sizeOptions: DropdownOption[] = [
+    { value: 'xs', label: 'Extra Small' },
+    { value: 's', label: 'Small' },
+    { value: 'm', label: 'Medium' },
+    { value: 'l', label: 'Large' },
+    { value: 'xl', label: 'Extra Large' },
+  ];
+
+  return (
+    <form>
+      <Dropdown
+        id="product-size"
+        label="Size"
+        options={sizeOptions}
+        value={formData.size}
+        onChange={(value) => setFormData({ ...formData, size: value })}
+        required
+        error={submitted && !formData.size}
+        errorMessage="Please select a size"
+      />
+    </form>
+  );
+};
+```
+
+### Cascading Dropdowns
+```tsx
+const LocationSelector = () => {
+  const [country, setCountry] = useState('');
+  const [state, setState] = useState('');
+
+  const stateOptions = country ? getStatesByCountry(country) : [];
+
+  return (
+    <>
+      <Dropdown
+        id="country"
+        label="Country"
+        options={countryOptions}
+        value={country}
+        onChange={(value) => {
+          setCountry(value);
+          setState(''); // Reset state when country changes
+        }}
+      />
+      
+      <Dropdown
+        id="state"
+        label="State/Province"
+        options={stateOptions}
+        value={state}
+        onChange={setState}
+        disabled={!country}
+        placeholder={country ? 'Select a state' : 'Select country first'}
+      />
+    </>
+  );
+};
+```
+
+### Filter Dropdown
+```tsx
+const ProductFilter = () => {
+  const [sortBy, setSortBy] = useState('featured');
+
+  const sortOptions: DropdownOption[] = [
+    { value: 'featured', label: 'Featured' },
+    { value: 'price-low', label: 'Price: Low to High' },
+    { value: 'price-high', label: 'Price: High to Low' },
+    { value: 'newest', label: 'Newest First' },
+    { value: 'rating', label: 'Highest Rated' },
+  ];
+
+  return (
+    <Dropdown
+      id="sort-products"
+      label="Sort By"
+      options={sortOptions}
+      value={sortBy}
+      onChange={setSortBy}
+      aria-label="Sort products by"
+    />
+  );
+};
+```
+
+## Testing
+The component includes comprehensive tests covering:
+- Rendering in all states
+- User interactions (click, keyboard)
+- Option selection and disabled options
+- Accessibility features
+- Error states
+- Form compatibility
+- Edge cases
+
+Run tests with: `npm run test Dropdown.test.tsx`

--- a/public/chevron-down.svg
+++ b/public/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7L9.9375 12.9375L15.875 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -3,9 +3,93 @@
 import React, { useState } from 'react';
 import Button from '@/components/atoms/Button/Button';
 import Chip from '@/components/atoms/Chip/Chip';
+import Dropdown, { DropdownOption } from '@/components/atoms/Dropdown/Dropdown';
 import RadioButtonSelector from '@/components/atoms/RadioButtonSelector/RadioButtonSelector';
 import QuantitySelector from '@/components/molecules/QuantitySelector/QuantitySelector';
 import styles from './page.module.scss';
+
+const DropdownDemo = () => {
+  const [selectedSize, setSelectedSize] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('electronics');
+  const [selectedShipping, setSelectedShipping] = useState('');
+
+  const sizeOptions: DropdownOption[] = [
+    { value: 'xs', label: 'Extra Small' },
+    { value: 's', label: 'Small' },
+    { value: 'm', label: 'Medium' },
+    { value: 'l', label: 'Large' },
+    { value: 'xl', label: 'Extra Large' },
+  ];
+
+  const categoryOptions: DropdownOption[] = [
+    { value: 'electronics', label: 'Electronics' },
+    { value: 'clothing', label: 'Clothing & Accessories' },
+    { value: 'home', label: 'Home & Garden' },
+    { value: 'toys', label: 'Toys & Games' },
+    { value: 'books', label: 'Books & Media' },
+  ];
+
+  const shippingOptions: DropdownOption[] = [
+    { value: 'standard', label: 'Standard (5-7 days)' },
+    { value: 'express', label: 'Express (2-3 days)' },
+    { value: 'overnight', label: 'Overnight', disabled: true },
+    { value: 'pickup', label: 'Store Pickup' },
+  ];
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+      {/* Basic dropdown */}
+      <div style={{ maxWidth: '300px' }}>
+        <Dropdown
+          id="size-dropdown"
+          label="Size"
+          placeholder="Select a size"
+          options={sizeOptions}
+          value={selectedSize}
+          onChange={setSelectedSize}
+        />
+      </div>
+
+      {/* Dropdown with pre-selected value */}
+      <div style={{ maxWidth: '300px' }}>
+        <Dropdown
+          id="category-dropdown"
+          label="Category"
+          options={categoryOptions}
+          value={selectedCategory}
+          onChange={setSelectedCategory}
+          required
+        />
+      </div>
+
+      {/* Dropdown with disabled options */}
+      <div style={{ maxWidth: '300px' }}>
+        <Dropdown
+          id="shipping-dropdown"
+          label="Shipping Method"
+          placeholder="Choose shipping"
+          options={shippingOptions}
+          value={selectedShipping}
+          onChange={setSelectedShipping}
+          error={!selectedShipping}
+          errorMessage="Please select a shipping method"
+        />
+      </div>
+
+      {/* Disabled dropdown */}
+      <div style={{ maxWidth: '300px' }}>
+        <Dropdown
+          id="disabled-dropdown"
+          label="Disabled Dropdown"
+          options={sizeOptions}
+          value="m"
+          onChange={() => {}}
+          disabled
+        />
+      </div>
+    </div>
+  );
+};
 
 const RadioButtonSelectorDemo = () => {
   const [selectedValue, setSelectedValue] = useState('option2');
@@ -338,6 +422,76 @@ const RadioGroup = () => {
     </div>
   );
 };`}</pre>
+                </div>
+              </div>
+
+              {/* Dropdown Component */}
+              <div className={styles.showcase__componentShowcase}>
+                <div className={styles.showcase__componentHeader}>
+                  <h3 className={styles.showcase__componentName}>Dropdown</h3>
+                  <span className={styles.showcase__componentPath}>
+                    components/atoms/Dropdown
+                  </span>
+                </div>
+                
+                <div className={styles.showcase__componentDemo}>
+                  <DropdownDemo />
+                </div>
+                
+                <div className={styles.showcase__componentCode}>
+                  <pre>{`// Basic usage
+import Dropdown, { DropdownOption } from '@/components/atoms/Dropdown/Dropdown';
+
+const options: DropdownOption[] = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+];
+
+<Dropdown
+  id="size"
+  label="Size"
+  options={options}
+  value={selected}
+  onChange={setSelected}
+/>
+
+// With placeholder
+<Dropdown
+  id="category"
+  placeholder="Choose a category"
+  options={categoryOptions}
+  value={category}
+  onChange={setCategory}
+/>
+
+// With disabled options
+const shippingOptions: DropdownOption[] = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'express', label: 'Express' },
+  { value: 'overnight', label: 'Overnight', disabled: true },
+];
+
+// With error state
+<Dropdown
+  id="required-field"
+  label="Required Field"
+  options={options}
+  value={value}
+  onChange={setValue}
+  required
+  error={!value}
+  errorMessage="This field is required"
+/>
+
+// Disabled state
+<Dropdown
+  id="disabled"
+  label="Disabled"
+  options={options}
+  value="medium"
+  disabled
+/>`}</pre>
                 </div>
               </div>
               

--- a/src/components/atoms/Dropdown/Dropdown.module.scss
+++ b/src/components/atoms/Dropdown/Dropdown.module.scss
@@ -1,0 +1,178 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
+.dropdown {
+  position: relative;
+  width: 100%;
+
+  &__label {
+    display: block;
+    font-family: $font-family-primary;
+    font-size: $font-size-sm; // 14px
+    font-weight: $font-weight-medium;
+    line-height: $line-height-normal;
+    color: $text-primary;
+    margin-bottom: $spacing-2; // 8px
+  }
+
+  &__required {
+    color: $color-error;
+    margin-left: $spacing-1; // 4px
+  }
+
+  &__trigger {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    min-height: $input-height-lg; // 48px
+    padding: $spacing-3; // 12px
+    background-color: $white; // #FFFFFF from Figma
+    border: 1px solid $gray-600; // #757575 from Figma
+    border-radius: $radius-sm; // 4px from Figma
+    box-shadow: $shadow-radio-selector; // 0px 4px 16px 0px rgba(55,58,64,0.15) from Figma
+    font-family: $font-family-primary; // Sofia Pro from Figma, using Inter
+    font-size: $font-size-base; // 16px from Figma
+    font-weight: $font-weight-medium; // Medium from Figma
+    line-height: $line-height-normal;
+    color: $black; // #000000 from Figma
+    cursor: pointer;
+    transition: all $transition-base;
+    text-align: left;
+
+    &:hover:not(&--disabled) {
+      border-color: $purple-primary;
+    }
+
+    &:focus {
+      outline: 2px solid $purple-primary;
+      outline-offset: 2px;
+    }
+
+    &--open {
+      border-color: $purple-primary;
+    }
+
+    &--error {
+      border-color: $color-error;
+
+      &:hover:not(&--disabled) {
+        border-color: $color-error;
+      }
+    }
+
+    &--disabled {
+      background-color: $gray-100;
+      color: $text-disabled;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  &__value {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-right: $spacing-2; // 8px
+
+    &--placeholder {
+      color: $text-secondary;
+    }
+  }
+
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $spacing-5; // 20px from Figma
+    height: $spacing-5; // 20px
+    flex-shrink: 0;
+    transition: transform $transition-base;
+
+    &--rotated {
+      transform: rotate(180deg);
+    }
+  }
+
+  &__chevron {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__menu {
+    position: absolute;
+    top: calc(100% + $spacing-1); // 4px gap
+    left: 0;
+    right: 0;
+    max-height: 240px;
+    overflow-y: auto;
+    background-color: $white;
+    border: 1px solid $gray-300;
+    border-radius: $radius-sm;
+    box-shadow: $shadow-lg;
+    z-index: $z-index-dropdown;
+    list-style: none;
+    margin: 0;
+    padding: $spacing-1 0; // 4px vertical padding
+  }
+
+  &__option {
+    padding: $spacing-2 $spacing-3; // 8px 12px
+    font-family: $font-family-primary;
+    font-size: $font-size-base;
+    font-weight: $font-weight-normal;
+    line-height: $line-height-normal;
+    color: $text-primary;
+    cursor: pointer;
+    transition: background-color $transition-fast;
+
+    &:hover:not(&--disabled) {
+      background-color: $gray-100;
+    }
+
+    &:focus {
+      outline: 2px solid $purple-primary;
+      outline-offset: -2px;
+    }
+
+    &--selected {
+      background-color: $purple-lightest;
+      color: $purple-primary;
+      font-weight: $font-weight-medium;
+    }
+
+    &--disabled {
+      color: $text-disabled;
+      cursor: not-allowed;
+      opacity: 0.6;
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
+  }
+
+  &__error {
+    margin-top: $spacing-1; // 4px
+    font-family: $font-family-primary;
+    font-size: $font-size-sm; // 14px
+    font-weight: $font-weight-normal;
+    line-height: $line-height-normal;
+    color: $color-error;
+  }
+
+  &__hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}

--- a/src/components/atoms/Dropdown/Dropdown.test.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Dropdown, { DropdownOption } from './Dropdown';
+
+describe('Dropdown', () => {
+  const mockOptions: DropdownOption[] = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+    { value: 'option3', label: 'Option 3', disabled: true },
+  ];
+
+  const defaultProps = {
+    id: 'test-dropdown',
+    options: mockOptions,
+    onChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with required props', () => {
+    render(<Dropdown {...defaultProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+  });
+
+  it('renders with custom placeholder', () => {
+    render(<Dropdown {...defaultProps} placeholder="Choose one" />);
+    expect(screen.getByText('Choose one')).toBeInTheDocument();
+  });
+
+  it('renders with label', () => {
+    render(<Dropdown {...defaultProps} label="Test Label" />);
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByLabelText('Test Label')).toBeInTheDocument();
+  });
+
+  it('renders with required indicator', () => {
+    render(<Dropdown {...defaultProps} label="Test Label" required />);
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('opens dropdown when clicked', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  it('closes dropdown when clicking outside', async () => {
+    render(
+      <div>
+        <Dropdown {...defaultProps} />
+        <div data-testid="outside">Outside</div>
+      </div>
+    );
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    await waitFor(() => {
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  it('selects option when clicked', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    fireEvent.click(screen.getByText('Option 2'));
+    
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(defaultProps.onChange).toHaveBeenCalledWith('option2');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('does not select disabled option', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    fireEvent.click(screen.getByText('Option 3'));
+    
+    expect(defaultProps.onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders with pre-selected value', () => {
+    render(<Dropdown {...defaultProps} value="option2" />);
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  it('updates when value prop changes', () => {
+    const { rerender } = render(<Dropdown {...defaultProps} value="option1" />);
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    
+    rerender(<Dropdown {...defaultProps} value="option2" />);
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  it('handles keyboard navigation', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    // Open with Enter
+    fireEvent.keyDown(button, { key: 'Enter' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    
+    // Close with Escape
+    fireEvent.keyDown(button, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    
+    // Open with Space
+    fireEvent.keyDown(button, { key: ' ' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    
+    // Open with ArrowDown
+    fireEvent.keyDown(button, { key: 'Escape' });
+    fireEvent.keyDown(button, { key: 'ArrowDown' });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders in disabled state', () => {
+    render(<Dropdown {...defaultProps} disabled />);
+    const button = screen.getByRole('button');
+    
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('renders with error state', () => {
+    render(<Dropdown {...defaultProps} error errorMessage="This field is required" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('This field is required');
+    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Dropdown {...defaultProps} className="custom-class" />);
+    expect(container.querySelector('.dropdown')).toHaveClass('custom-class');
+  });
+
+  it('uses aria-label when provided', () => {
+    render(<Dropdown {...defaultProps} aria-label="Custom label" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Custom label');
+  });
+
+  it('uses label as aria-label when aria-label not provided', () => {
+    render(<Dropdown {...defaultProps} label="Test Label" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Test Label');
+  });
+
+  it('has proper ARIA attributes', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    expect(button).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('includes hidden select for form compatibility', () => {
+    render(<Dropdown {...defaultProps} name="test-select" />);
+    const hiddenSelect = document.querySelector('select[name="test-select"]');
+    
+    expect(hiddenSelect).toBeInTheDocument();
+    expect(hiddenSelect).toHaveAttribute('aria-hidden', 'true');
+    expect(hiddenSelect).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('marks selected option with aria-selected', () => {
+    render(<Dropdown {...defaultProps} value="option2" />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    const options = screen.getAllByRole('option');
+    
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+    expect(options[2]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('marks disabled options with aria-disabled', () => {
+    render(<Dropdown {...defaultProps} />);
+    const button = screen.getByRole('button');
+    
+    fireEvent.click(button);
+    const options = screen.getAllByRole('option');
+    
+    expect(options[0]).toHaveAttribute('aria-disabled', 'false');
+    expect(options[1]).toHaveAttribute('aria-disabled', 'false');
+    expect(options[2]).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/src/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import Image from 'next/image';
+import styles from './Dropdown.module.scss';
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface DropdownProps {
+  id: string;
+  name?: string;
+  label?: string;
+  placeholder?: string;
+  options: DropdownOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+  required?: boolean;
+  error?: boolean;
+  errorMessage?: string;
+  className?: string;
+  'aria-label'?: string;
+  'aria-describedby'?: string;
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  id,
+  name,
+  label,
+  placeholder = 'Select an option',
+  options,
+  value,
+  onChange,
+  disabled = false,
+  required = false,
+  error = false,
+  errorMessage,
+  className,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedby,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(value || '');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setSelectedValue(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [isOpen]);
+
+  const handleToggle = () => {
+    if (!disabled) {
+      setIsOpen(!isOpen);
+    }
+  };
+
+  const handleSelect = (optionValue: string) => {
+    if (!disabled) {
+      setSelectedValue(optionValue);
+      setIsOpen(false);
+      if (onChange) {
+        onChange(optionValue);
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+
+    switch (e.key) {
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        handleToggle();
+        break;
+      case 'Escape':
+        setIsOpen(false);
+        buttonRef.current?.focus();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+        break;
+    }
+  };
+
+  const selectedOption = options.find(opt => opt.value === selectedValue);
+  const displayLabel = selectedOption ? selectedOption.label : placeholder;
+
+  return (
+    <div className={`${styles.dropdown} ${className || ''}`} ref={dropdownRef}>
+      {label && (
+        <label htmlFor={id} className={styles.dropdown__label}>
+          {label}
+          {required && <span className={styles.dropdown__required}>*</span>}
+        </label>
+      )}
+      
+      <button
+        ref={buttonRef}
+        id={id}
+        type="button"
+        className={`${styles.dropdown__trigger} ${
+          isOpen ? styles['dropdown__trigger--open'] : ''
+        } ${error ? styles['dropdown__trigger--error'] : ''} ${
+          disabled ? styles['dropdown__trigger--disabled'] : ''
+        }`}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label={ariaLabel || label || 'Select an option'}
+        aria-describedby={ariaDescribedby}
+      >
+        <span className={`${styles.dropdown__value} ${
+          !selectedValue ? styles['dropdown__value--placeholder'] : ''
+        }`}>
+          {displayLabel}
+        </span>
+        <div className={`${styles.dropdown__icon} ${
+          isOpen ? styles['dropdown__icon--rotated'] : ''
+        }`}>
+          <Image
+            src="/chevron-down.svg"
+            alt=""
+            width={20}
+            height={20}
+            className={styles.dropdown__chevron}
+          />
+        </div>
+      </button>
+
+      {isOpen && (
+        <ul
+          className={styles.dropdown__menu}
+          role="listbox"
+          aria-labelledby={id}
+        >
+          {options.map((option) => (
+            <li
+              key={option.value}
+              role="option"
+              className={`${styles.dropdown__option} ${
+                option.disabled ? styles['dropdown__option--disabled'] : ''
+              } ${
+                selectedValue === option.value ? styles['dropdown__option--selected'] : ''
+              }`}
+              onClick={() => !option.disabled && handleSelect(option.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !option.disabled) {
+                  handleSelect(option.value);
+                }
+              }}
+              aria-selected={selectedValue === option.value}
+              aria-disabled={option.disabled}
+              tabIndex={option.disabled ? -1 : 0}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && errorMessage && (
+        <p className={styles.dropdown__error} role="alert">
+          {errorMessage}
+        </p>
+      )}
+
+      {/* Hidden select for form compatibility */}
+      <select
+        name={name || id}
+        value={selectedValue}
+        onChange={(e) => handleSelect(e.target.value)}
+        disabled={disabled}
+        required={required}
+        className={styles.dropdown__hidden}
+        aria-hidden="true"
+        tabIndex={-1}
+      >
+        <option value="">{placeholder}</option>
+        {options.map(option => (
+          <option key={option.value} value={option.value} disabled={option.disabled}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
## Summary
- Implement custom-styled dropdown component with full accessibility support
- Add support for disabled options, error states, and keyboard navigation
- Map all Figma design values to design system variables

## Changes
- Created Dropdown atom component with TypeScript interfaces
- Implemented keyboard navigation (Enter/Space/Escape/ArrowDown)
- Added support for disabled options and error states
- Included comprehensive test suite covering all functionality
- Added detailed documentation with usage examples
- Integrated component into showcase page with multiple demos
- Added chevron-down.svg icon for dropdown indicator

## Design Reference
- Figma: https://www.figma.com/design/ri9qaHxsKZS00ViWhwguiP/%F0%9F%93%8C-PS-Components?node-id=18-304&m=dev

## Features
- ✅ Custom styled dropdown matching Figma design
- ✅ Full keyboard navigation support
- ✅ ARIA compliant with proper roles and states
- ✅ Support for disabled options
- ✅ Error state with custom messages
- ✅ Hidden native select for form compatibility
- ✅ Click outside to close
- ✅ Responsive and accessible

## Testing
- Comprehensive test suite with 20+ test cases
- Covers all user interactions and edge cases
- Accessibility tests included

Closes #4