### PR TITLE
feat: Add LocationPicker component from Figma design (#20)

### DIFF
--- a/docs/LocationPicker.md
+++ b/docs/LocationPicker.md
@@ -1,0 +1,183 @@
+# LocationPicker Component
+
+A location display component that shows a pickup or delivery address with an edit button for changing the location.
+
+## Figma Reference
+
+- URL: https://www.figma.com/design/ri9qaHxsKZS00ViWhwguiP/%F0%9F%93%8C-PS-Components?node-id=535-1336&m=dev
+- Node ID: 535:1336
+
+## Usage
+
+```tsx
+import LocationPicker from '@/components/molecules/LocationPicker/LocationPicker';
+
+// Basic usage
+<LocationPicker
+  address="315 N Main St, Atlanta GA"
+  onEdit={() => handleEditLocation()}
+/>
+
+// With custom label
+<LocationPicker
+  label="Delivery address"
+  address="123 Delivery St, Nashville TN"
+  onEdit={() => openLocationModal()}
+/>
+
+// With custom styling
+<LocationPicker
+  address="456 Oak Ave, Memphis TN"
+  onEdit={() => navigateToLocationPicker()}
+  className="location-section"
+/>
+
+// With custom aria label
+<LocationPicker
+  address="789 Pine Rd, Knoxville TN"
+  onEdit={() => handleChangeLocation()}
+  editAriaLabel="Change store location"
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `address` | `string` | Required | The address to display |
+| `onEdit` | `() => void` | Required | Callback when edit button is clicked |
+| `label` | `string` | `'Picking up at'` | The label text above the address |
+| `className` | `string` | - | Additional CSS class names |
+| `editAriaLabel` | `string` | `'Edit pickup location'` | ARIA label for the edit button |
+
+## Design Specifications
+
+- **Label**: 
+  - Color: #7A7A7A (mapped to $gray-750)
+  - Font size: 12px
+  - Font weight: 500 (medium)
+- **Address**: 
+  - Color: #1F1F1F (mapped to $black-primary)
+  - Font size: 16px
+  - Font weight: 600 (semibold)
+  - Text decoration: underline
+- **Gap**: 5px between label and address
+- **Edit icon**: 
+  - Size: 20px × 23px
+  - Path: `/public/edit.svg`
+
+## Component Details
+
+The LocationPicker component displays location information with an editable option. The address text is underlined to indicate it's associated with the location, and an edit icon button allows users to modify the location.
+
+## Accessibility
+
+- Edit button has proper ARIA label for screen readers
+- Keyboard navigation supported with focus indicators
+- Semantic HTML structure with button element
+
+## Testing
+
+Run tests with:
+
+```bash
+npm run test -- LocationPicker.test.tsx
+```
+
+Test coverage includes:
+- Rendering with various prop combinations
+- Click handler functionality
+- Custom label and aria label support
+- Long address handling
+- Focus management
+- Component structure verification
+
+## Examples
+
+### Store Pickup Location
+
+```tsx
+function StorePickup() {
+  const [pickupStore, setPickupStore] = useState({
+    address: '315 N Main St, Atlanta GA'
+  });
+
+  const handleEditLocation = () => {
+    // Open store selector modal
+    openStoreSelector();
+  };
+
+  return (
+    <div className="pickup-section">
+      <LocationPicker
+        address={pickupStore.address}
+        onEdit={handleEditLocation}
+      />
+      <p>Store closes at 9pm</p>
+    </div>
+  );
+}
+```
+
+### Delivery Address
+
+```tsx
+function DeliveryInfo() {
+  const { deliveryAddress, openAddressBook } = useDelivery();
+
+  return (
+    <LocationPicker
+      label="Delivery address"
+      address={deliveryAddress}
+      onEdit={openAddressBook}
+      editAriaLabel="Change delivery address"
+    />
+  );
+}
+```
+
+### Multiple Locations
+
+```tsx
+function LocationsList() {
+  const locations = [
+    { id: 1, type: 'Pickup', address: '123 Main St, City A' },
+    { id: 2, type: 'Delivery', address: '456 Oak Ave, City B' },
+  ];
+
+  return (
+    <div className="locations-list">
+      {locations.map((location) => (
+        <LocationPicker
+          key={location.id}
+          label={`${location.type} location`}
+          address={location.address}
+          onEdit={() => editLocation(location.id)}
+          className="location-item"
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+### In Order Summary
+
+```tsx
+function OrderSummary() {
+  const { order, updatePickupLocation } = useOrder();
+
+  return (
+    <div className="order-summary">
+      <h2>Order Details</h2>
+      <LocationPicker
+        address={order.pickupLocation}
+        onEdit={updatePickupLocation}
+      />
+      <div className="order-items">
+        {/* Order items list */}
+      </div>
+    </div>
+  );
+}
+```

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -10,6 +10,7 @@ import CartHeader from '@/components/atoms/CartHeader/CartHeader';
 import QuantitySelector from '@/components/molecules/QuantitySelector/QuantitySelector';
 import CategoryTile from '@/components/molecules/CategoryTile/CategoryTile';
 import OrderStatus, { OrderStatusType } from '@/components/molecules/OrderStatus/OrderStatus';
+import LocationPicker from '@/components/molecules/LocationPicker/LocationPicker';
 import styles from './page.module.scss';
 
 const DropdownDemo = () => {
@@ -334,6 +335,70 @@ const OrderStatusDemo = () => {
           {...storeInfo}
           onEdit={() => console.log('Edit store location')}
           onViewOrders={() => console.log('View your orders')}
+        />
+      </div>
+    </div>
+  );
+};
+
+const LocationPickerDemo = () => {
+  const [selectedLocation, setSelectedLocation] = useState('315 N Main St, Atlanta GA');
+
+  const locations = [
+    '315 N Main St, Atlanta GA',
+    '123 Oak Avenue, Nashville TN 37201',
+    '456 Elm Street, Memphis TN 38103',
+    '789 Pine Road, Knoxville TN 37902',
+  ];
+
+  const handleEditLocation = () => {
+    // Simulate location change
+    const currentIndex = locations.indexOf(selectedLocation);
+    const nextIndex = (currentIndex + 1) % locations.length;
+    setSelectedLocation(locations[nextIndex]);
+    console.log('Location changed to:', locations[nextIndex]);
+  };
+
+  return (
+    <div className={styles.showcase__demoLayout}>
+      {/* Default usage */}
+      <div style={{ maxWidth: '400px' }}>
+        <h4 style={{ fontSize: '14px', fontWeight: '500', marginBottom: '8px', color: '#666' }}>Default Pickup Location</h4>
+        <LocationPicker
+          address={selectedLocation}
+          onEdit={handleEditLocation}
+        />
+      </div>
+
+      {/* With custom label */}
+      <div style={{ maxWidth: '400px' }}>
+        <h4 style={{ fontSize: '14px', fontWeight: '500', marginBottom: '8px', color: '#666' }}>Delivery Address</h4>
+        <LocationPicker
+          label="Delivery address"
+          address="456 Oak St, Suite 200, Nashville TN"
+          onEdit={() => console.log('Edit delivery address')}
+          editAriaLabel="Change delivery address"
+        />
+      </div>
+
+      {/* Long address */}
+      <div style={{ maxWidth: '400px' }}>
+        <h4 style={{ fontSize: '14px', fontWeight: '500', marginBottom: '8px', color: '#666' }}>Long Address</h4>
+        <LocationPicker
+          label="Ship to"
+          address="1234 Very Long Street Name, Building B, Apt 567, Some City, State 12345"
+          onEdit={() => console.log('Edit shipping address')}
+        />
+      </div>
+
+      {/* Different label */}
+      <div style={{ maxWidth: '400px' }}>
+        <h4 style={{ fontSize: '14px', fontWeight: '500', marginBottom: '8px', color: '#666' }}>Store Location</h4>
+        <LocationPicker
+          label="Your selected store"
+          address="PopShelf #123, Goodlettsville TN"
+          onEdit={() => console.log('Change store')}
+          editAriaLabel="Select a different store"
         />
       </div>
     </div>
@@ -1059,6 +1124,66 @@ const OrderTracker = () => {
       onEdit={handleEditStore}
       onViewOrders={status === OrderStatusType.MULTIPLE_ORDERS ? viewOrders : undefined}
     />
+  );
+};`}</pre>
+                </div>
+              </div>
+              
+              {/* LocationPicker Component */}
+              <div className={styles.showcase__componentShowcase}>
+                <div className={styles.showcase__componentHeader}>
+                  <h3 className={styles.showcase__componentName}>LocationPicker</h3>
+                  <span className={styles.showcase__componentPath}>
+                    components/molecules/LocationPicker
+                  </span>
+                </div>
+                
+                <div className={styles.showcase__componentDemo}>
+                  <LocationPickerDemo />
+                </div>
+                
+                <div className={styles.showcase__componentCode}>
+                  <pre>{`// Basic usage
+<LocationPicker
+  address="315 N Main St, Atlanta GA"
+  onEdit={() => handleEditLocation()}
+/>
+
+// With custom label
+<LocationPicker
+  label="Delivery address"
+  address="123 Delivery St, Nashville TN"
+  onEdit={() => openLocationModal()}
+/>
+
+// With custom aria label
+<LocationPicker
+  address="789 Pine Rd, Knoxville TN"
+  onEdit={() => handleChangeLocation()}
+  editAriaLabel="Change store location"
+/>
+
+// Implementation example
+const StorePickup = () => {
+  const [store, setStore] = useState({
+    address: '315 N Main St, Atlanta GA'
+  });
+
+  const handleEditLocation = () => {
+    // Open store selector modal
+    openStoreSelector((newStore) => {
+      setStore(newStore);
+    });
+  };
+
+  return (
+    <div className="pickup-section">
+      <LocationPicker
+        address={store.address}
+        onEdit={handleEditLocation}
+      />
+      <p>Store closes at {store.closingTime}</p>
+    </div>
   );
 };`}</pre>
                 </div>

--- a/src/components/molecules/LocationPicker/LocationPicker.module.scss
+++ b/src/components/molecules/LocationPicker/LocationPicker.module.scss
@@ -1,0 +1,66 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
+.location-picker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $location-picker-label-gap; // 5px from Figma
+    flex: 1;
+  }
+
+  &__label {
+    @include font-medium; // 500 weight
+    font-size: $font-size-xs; // 12px
+    line-height: 1; // 12px line height
+    color: $gray-750; // #7A7A7A
+  }
+
+  &__address {
+    @include font-semibold; // 600 weight
+    font-size: $font-size-base; // 16px
+    line-height: 1; // 16px line height
+    color: $black-primary; // #1F1F1F
+    text-decoration: underline;
+    text-decoration-skip-ink: none;
+    text-underline-position: from-font;
+  }
+
+  &__edit-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $location-picker-icon-width; // 20px
+    height: $location-picker-icon-height; // 23px
+    transition: opacity $transition-fast;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    &:focus {
+      outline: 2px solid $purple-primary;
+      outline-offset: $spacing-1 / 2; // 2px
+      border-radius: $radius-sm;
+    }
+
+    &:active {
+      opacity: 0.5;
+    }
+  }
+
+  &__edit-icon {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+}

--- a/src/components/molecules/LocationPicker/LocationPicker.test.tsx
+++ b/src/components/molecules/LocationPicker/LocationPicker.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LocationPicker from './LocationPicker';
+
+// Mock Next.js Image component
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+    return <img {...props} />;
+  },
+}));
+
+describe('LocationPicker', () => {
+  const defaultProps = {
+    address: '315 N Main St, Atlanta GA',
+    onEdit: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with required props', () => {
+    render(<LocationPicker {...defaultProps} />);
+    
+    expect(screen.getByText('Picking up at')).toBeInTheDocument();
+    expect(screen.getByText('315 N Main St, Atlanta GA')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit pickup location' })).toBeInTheDocument();
+  });
+
+  it('renders with custom label', () => {
+    render(
+      <LocationPicker {...defaultProps} label="Delivery address" />
+    );
+    
+    expect(screen.getByText('Delivery address')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <LocationPicker {...defaultProps} className="custom-class" />
+    );
+    
+    const component = container.firstChild as HTMLElement;
+    expect(component).toHaveClass('custom-class');
+  });
+
+  it('calls onEdit when edit button is clicked', () => {
+    render(<LocationPicker {...defaultProps} />);
+    
+    const editButton = screen.getByRole('button', { name: 'Edit pickup location' });
+    fireEvent.click(editButton);
+    
+    expect(defaultProps.onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom aria label for edit button', () => {
+    render(
+      <LocationPicker 
+        {...defaultProps} 
+        editAriaLabel="Change delivery location" 
+      />
+    );
+    
+    expect(screen.getByRole('button', { name: 'Change delivery location' })).toBeInTheDocument();
+  });
+
+  it('displays address with underline styling', () => {
+    render(<LocationPicker {...defaultProps} />);
+    
+    const address = screen.getByText('315 N Main St, Atlanta GA');
+    expect(address).toHaveClass('location-picker__address');
+  });
+
+  it('renders edit icon', () => {
+    render(<LocationPicker {...defaultProps} />);
+    
+    const icon = screen.getByAltText('');
+    expect(icon).toHaveAttribute('src', '/edit.svg');
+    expect(icon).toHaveAttribute('width', '20');
+    expect(icon).toHaveAttribute('height', '23');
+  });
+
+  it('handles long addresses', () => {
+    const longAddress = '1234 Very Long Street Name, Apartment Complex Building B, Suite 567, Some City With A Long Name, State 12345';
+    render(
+      <LocationPicker {...defaultProps} address={longAddress} />
+    );
+    
+    expect(screen.getByText(longAddress)).toBeInTheDocument();
+  });
+
+  it('maintains focus on edit button after click', () => {
+    render(<LocationPicker {...defaultProps} />);
+    
+    const editButton = screen.getByRole('button', { name: 'Edit pickup location' });
+    fireEvent.click(editButton);
+    
+    expect(document.activeElement).toBe(editButton);
+  });
+
+  it('has correct structure for label and address', () => {
+    const { container } = render(<LocationPicker {...defaultProps} />);
+    
+    const content = container.querySelector('.location-picker__content');
+    expect(content).toBeInTheDocument();
+    
+    const label = content?.querySelector('.location-picker__label');
+    expect(label).toHaveTextContent('Picking up at');
+    
+    const address = content?.querySelector('.location-picker__address');
+    expect(address).toHaveTextContent('315 N Main St, Atlanta GA');
+  });
+});

--- a/src/components/molecules/LocationPicker/LocationPicker.tsx
+++ b/src/components/molecules/LocationPicker/LocationPicker.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import styles from './LocationPicker.module.scss';
+
+interface LocationPickerProps {
+  /** The label text above the address */
+  label?: string;
+  /** The address to display */
+  address: string;
+  /** Callback when edit button is clicked */
+  onEdit: () => void;
+  /** Additional CSS class names */
+  className?: string;
+  /** ARIA label for the edit button */
+  editAriaLabel?: string;
+}
+
+const LocationPicker: React.FC<LocationPickerProps> = ({
+  label = 'Picking up at',
+  address,
+  onEdit,
+  className,
+  editAriaLabel = 'Edit pickup location',
+}) => {
+  return (
+    <div className={`${styles['location-picker']} ${className || ''}`}>
+      <div className={styles['location-picker__content']}>
+        <span className={styles['location-picker__label']}>{label}</span>
+        <span className={styles['location-picker__address']}>{address}</span>
+      </div>
+      <button
+        type="button"
+        className={styles['location-picker__edit-button']}
+        onClick={onEdit}
+        aria-label={editAriaLabel}
+      >
+        <Image
+          src="/edit.svg"
+          alt=""
+          width={20}
+          height={23}
+          className={styles['location-picker__edit-icon']}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default LocationPicker;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -22,8 +22,10 @@ $blue-info: #00B8D4;
 
 // Neutral Colors (from Figma)
 $black: #000000;
+$black-primary: #1F1F1F; // Used in LocationPicker address (from Figma)
 $gray-900: #212121;
 $gray-800: #424242;
+$gray-750: #7A7A7A; // Used in LocationPicker label (from Figma)
 $gray-700: #636363; // Used in text field labels (from Figma)
 $gray-600: #757575; // Used in multiline secondary labelTop and text field placeholders
 $gray-500: #9E9E9E;
@@ -284,3 +286,8 @@ $nav-shadow: $shadow-sm;
 // Footer
 $footer-background: $gray-900;
 $footer-text: $text-inverse;
+
+// LocationPicker Component
+$location-picker-label-gap: 5px; // Gap between label and address (from Figma)
+$location-picker-icon-width: 20px; // Edit icon width
+$location-picker-icon-height: 23px; // Edit icon height


### PR DESCRIPTION
## Summary
- ✨ Create LocationPicker molecule component from Figma design
- 🎨 Implement underlined address with edit functionality
- 🔧 Add callback prop for location editing

## Components Added
- **LocationPicker** (molecules level)
  - Location: `src/components/molecules/LocationPicker/`
  - Figma: https://www.figma.com/design/ri9qaHxsKZS00ViWhwguiP/%F0%9F%93%8C-PS-Components?node-id=535-1336&m=dev

## Features
- Displays pickup/delivery location with customizable label
- Underlined address text indicating it's related to location
- Edit icon button with callback for changing location
- Full accessibility support with ARIA labels
- Hover and focus states for edit button

## Design Specifications
- Label: 12px medium weight in #7A7A7A (mapped to $gray-750)
- Address: 16px semibold in #1F1F1F (mapped to $black-primary)
- Edit icon: 20×23px from `/public/edit.svg`
- 5px gap between label and address

## Test Coverage
- ✅ Rendering with various prop combinations
- ✅ Click handler functionality
- ✅ Custom label and ARIA label support
- ✅ Long address handling
- ✅ Focus management
- ✅ Component structure verification

## Design System Updates
- Added `$black-primary: #1F1F1F` for address text
- Added `$gray-750: #7A7A7A` for label text
- Added component-specific spacing variables

## Closes
Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)